### PR TITLE
stage select enhancements

### DIFF
--- a/scripts/stage-data.lua
+++ b/scripts/stage-data.lua
@@ -1,5 +1,4 @@
-STAGE_WRITE_FUNC_ADDR = 0xAEFA
-CURRENT_STAGE_ADDR    = 0xFF8101
+CURRENT_STAGE_ADDR = 0xFF8101
 
 STAGE_VALUES = {
 	FeastOfTheDamned    = 0x00,
@@ -41,7 +40,6 @@ stagesModule = {
 	["get_stage_name"] = get_stage_name,
 	["get_current_stage"] = get_current_stage,
 	["CURRENT_STAGE_ADDR"] = CURRENT_STAGE_ADDR,
-	["STAGE_WRITE_FUNC_ADDR"] = STAGE_WRITE_FUNC_ADDR,
-	["STAGE_VALUES"] = STAGE_VALUES
+	["STAGE_VALUES"] = STAGE_VALUES,
 }
 return stagesModule

--- a/scripts/stage-select.lua
+++ b/scripts/stage-select.lua
@@ -48,7 +48,7 @@ end
 
 local function override_stage_write()
 	if globals.desired_stage ~= nil then
-    memory.setregister("m68000.d0", globals.desired_stage)
+		memory.setregister("m68000.d0", globals.desired_stage)
 	end
 end
 
@@ -57,13 +57,13 @@ local function registerStart()
 end
 
 local function registerAfter()
-  if not globals.game_state.match_begun then
-    local inputs = joypad.getup()
-    if last_inputs ~= nil and inputs["P1 Coin"] == nil and last_inputs["P1 Coin"] == false then
-      globals.desired_stage = resolve_char_id_to_stage_value(memory.readbyte(P1_CHAR_SEL_CURS_ADDR))
-    end
-    last_inputs = inputs
-  end
+	if not globals.game_state.match_begun then
+		local inputs = joypad.getup()
+		if last_inputs ~= nil and inputs["P1 Coin"] == nil and last_inputs["P1 Coin"] == false then
+			globals.desired_stage = resolve_char_id_to_stage_value(memory.readbyte(P1_CHAR_SEL_CURS_ADDR))
+		end
+		last_inputs = inputs
+	end
 end
 
 stageSelectModule = {

--- a/scripts/vsav_training_master_script.lua
+++ b/scripts/vsav_training_master_script.lua
@@ -53,6 +53,7 @@ local hudModule          = require "./scripts/hud"
 local timersModule       = require "./scripts/timers"
 local throwTechModule    = require "./scripts/throwTech"
 local stageSelectModule  = require "./scripts/stage-select"
+local stageDataModule    = require "./scripts/stage-data"
 local vsavTestMenuModule = require "./scripts/vsav-test-menu"
 local soundModule        = require "./scripts/sound"
 
@@ -434,7 +435,7 @@ while true do
 		if globals.game_state and globals.game_state.match_begun == false then
 			gui.clearuncommitted()
 			if globals.desired_stage ~= nil then
-				gui.text(5, emu.screenheight() - 40, "Selected stage: " .. stageData.get_stage_name(globals.desired_stage))
+				gui.text(5, emu.screenheight() - 40, "Selected stage: " .. stageDataModule.get_stage_name(globals.desired_stage))
 			end
 			gui.text(0,0, 
 			"Open Input --> Map Game Inputs --> Lua Hotkey 1 and set it for the menu button\nSet Volume Up to record dummy    Volume Down for playback \nLua Hotkey 4 to return to CSS at any time"


### PR DESCRIPTION
Cleaning up stage select to overwrite D0 just before the game writes to memory rather than simply forcing state whenever the stage write function is called. This should reduce the chances of nasty side effects.