### PR TITLE
Feature: minimum number of inputs for pushblocks

### DIFF
--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -74,6 +74,7 @@ local default_training_settings = {
     game_speed = 3,
     bgm_on = true,
     lilith_gps = 0,
+    min_pb_inputs = 1,
   }
   
 

--- a/scripts/dummyState.lua
+++ b/scripts/dummyState.lua
@@ -440,6 +440,19 @@ local function get_p2_reversal_strength(player)
     end
 end
 
+local function set_min_pb_inputs()
+  local fn = nil
+  local min_inputs = globals.options.min_pb_inputs + 2
+  if min_inputs > 3 then
+    fn = function()
+      if memory.getregister("m68000.d0") < min_inputs then
+        memory.setregister("m68000.d0", 0x00000000)
+      end
+    end
+  end
+  memory.registerexec(0x2760E, fn)
+end
+
 local function set_lei_lei_stun_item()
     local current = globals.options.lei_lei_stun_item
     if globals and globals.getCharacter(0xFF8400) ~= "Lei-Lei" then 
@@ -654,6 +667,7 @@ dummyStateModule = {
         get_anak_projectile()
         set_lei_lei_stun_item()
         set_lilith_gloomy_puppet_show()
+        set_min_pb_inputs()
         return {
             get_dummy_state = get_dummy_state,
             -- parsed_dummy_state = parsed_dummy_state

--- a/scripts/frameskip-service-example.lua
+++ b/scripts/frameskip-service-example.lua
@@ -35,14 +35,16 @@ frameskip_observable = globals.frameskipService.get_framskip_pattern()
     print(data)
   end)
 
--- Let's say you want to know if the next frame will be skipped (DOES NOT WORK
--- TODAY, but for the sake of example), but don't really care when it won't be.
--- You want to filter the values of the get_next_frame_skipped observable:
-frameskip_observable = globals.frameskipService.get_next_frame_skipped()
-  -- only emits if value is `true`
-  :filter(function(frameSkipped) return frameSkipped == true end)
-  :subscribe(function(frameSkipped)
-    print(frameSkipped)
+-- Let's say you want to know if the next frame will be skipped or if the last
+-- frame was skipped. Then you want to filter the values of the 
+-- get_current_frame_frameskip_data_observable:
+frameskip_observable = globals.frameskipService.get_current_frame_frameskip_data()
+  -- will only emit if a frame was skipped or is about to be skipped
+  :filter(function(frame_skip_data)
+    return frame_skip_data.last_frame_was_skipped or frame_skip_data.next_frame_will_be_skipped
+  end)
+  :subscribe(function(frame_skip_data)
+    print(frame_skip_data)
   end)
 
 -- There are many other things you can do with observable data streams,

--- a/scripts/frameskip-service.lua
+++ b/scripts/frameskip-service.lua
@@ -59,9 +59,7 @@ local function is_nth_bit_set(value, n)
 end
 
 local frameskip_pattern_observable
-
 local current_frame_frameskip_data_observable
-
 local frameskipServiceModule = {
   ["registerStart"] = function()
     frameskip_pattern_observable = Rx.Observable.create(function(observer)

--- a/scripts/frameskip-service.lua
+++ b/scripts/frameskip-service.lua
@@ -1,4 +1,5 @@
 local global_settings_register_a5    = "m68000.a5"
+local register_d1                    = "m68000.d1"
 local global_settings_base_addr      = 0xFF8000
 local logical_frame_counter_offset   = 0x81
 local animation_frame_counter_offset = 0xB4
@@ -70,7 +71,7 @@ local frameskipServiceModule = {
     end)
     current_frame_frameskip_data_observable = Rx.Observable.create(function(observer)
       memory.registerexec(frameskip_next_frame_read_addr, function()
-        local frameskip_index = memory.getregister("m68000.d1")
+        local frameskip_index = memory.getregister(register_d1)
         local global_settings_addr = memory.getregister(global_settings_register_a5)
         local calculated_frameskip_index = bitwise_and(memory.readbyte(global_settings_base_addr + logical_frame_counter_offset), mod_32_bitmask)
         local frameskip_value = memory.readbyte(global_settings_addr + frameskip_flag_offset)

--- a/scripts/frameskip-service.lua
+++ b/scripts/frameskip-service.lua
@@ -1,5 +1,12 @@
+local global_settings_register_a5    = "m68000.a5"
+local global_settings_base_addr      = 0xFF8000
+local logical_frame_counter_offset   = 0x81
+local animation_frame_counter_offset = 0xB4
+local frameskip_flag_offset          = 0x118
+local last_frame_skipped_offset      = 0x134
 local frameskip_pattern_read_addr    = 0x8E5A
-local frameskip_next_frame_read_addr = 0x8E62
+local frameskip_next_frame_read_addr = 0x8E6A
+local mod_32_bitmask                 = 0x1F
 
 local function reverse_table_and_pad(tbl)
   for i = 1, math.floor(#tbl / 2) do
@@ -23,13 +30,37 @@ local function int_to_bits(int)
   return tbl
 end
 
+-- this implementaiton sucks lmao but whatever
+local function bitwise_and(int_a, int_b)
+  local a_bits = int_to_bits(int_a)
+  local b_bits = int_to_bits(int_b)
+  local anded_bits = {}
+  for i = 1, #a_bits do
+    local truth = a_bits[i] == 1 and b_bits[i] == 1
+    local result = 0
+    if truth then result = 1 end
+    table.insert(anded_bits, result)
+  end
+  return tonumber(table.concat(anded_bits), 2)
+end
+
+local function left_shift(int, num_shifts)
+  local int_bits = int_to_bits(int)
+  for i = 1, num_shifts do
+    table.insert(int_bits, #int_bits, table.remove(int_bits, 1))
+  end
+  return tonumber(table.concat(int_bits), 2)
+end
+
 local function is_nth_bit_set(value, n)
   local bits = int_to_bits(value)
   return bits[n + 1] == 1
 end
 
 local frameskip_pattern_observable
-local next_frame_will_be_skipped_observable
+
+local current_frame_frameskip_data_observable
+
 local frameskipServiceModule = {
   ["registerStart"] = function()
     frameskip_pattern_observable = Rx.Observable.create(function(observer)
@@ -37,11 +68,21 @@ local frameskipServiceModule = {
         observer:onNext(table.concat(int_to_bits(memory.getregister("m68000.d0"))))
       end)
     end)
-    next_frame_will_be_skipped_observable = Rx.Observable.create(function(observer)
+    current_frame_frameskip_data_observable = Rx.Observable.create(function(observer)
       memory.registerexec(frameskip_next_frame_read_addr, function()
-        local d0 = memory.getregister("m68000.d0")
-        local d1 = memory.getregister("m68000.d1")
-        observer:onNext(is_nth_bit_set(d0, d1))
+        local frameskip_index = memory.getregister("m68000.d1")
+        local global_settings_addr = memory.getregister(global_settings_register_a5)
+        local calculated_frameskip_index = bitwise_and(memory.readbyte(global_settings_base_addr + logical_frame_counter_offset), mod_32_bitmask)
+        local frameskip_value = memory.readbyte(global_settings_addr + frameskip_flag_offset)
+        local last_frame_skipped_value = memory.readbyte(global_settings_addr + last_frame_skipped_offset)
+        local animation_frame_counter = memory.readbyte(global_settings_base_addr + animation_frame_counter_offset)
+        observer:onNext({
+          frameskip_index = frameskip_index, -- seemingly 0 on skipped frames...
+          calculated_frameskip_index = calculated_frameskip_index, -- ...so we calculate it too
+          next_frame_will_be_skipped = frameskip_value == 0xFF,
+          last_frame_was_skipped = last_frame_skipped_value == 0xFF,
+          animation_frame_counter = animation_frame_counter
+        })
       end)
     end)
   end,
@@ -50,10 +91,23 @@ local frameskipServiceModule = {
   ["get_frameskip_pattern"] = function()
     return frameskip_pattern_observable
   end,
-  -- Emits `true` if the next frame will be skipped; `false` otherwise
+  -- Emits an object containing data about the current logical frame
+  -- 
+  -- `frameskip_index` is the value at `A5+0x81` at the time of frameskip
+  -- function return; this is `0` on skipped frames
+  -- 
+  -- `calculated_frameskip_index` is a reconstruction of what the frameskip
+  -- index should be, for use on skipped frames
+  -- 
+  -- `next_frame_will_be_skipped` `true` if the next animation frame will be
+  -- skipped
+  -- 
+  -- `last_frame_was_skipped` `true` if the last animation frame was skipped
+  -- 
+  -- `animation_frame_counter` the animation frame counter at `0xFF80B4`
   -- @returns {Observable}
-  ["get_next_frame_skipped"] = function()
-    return next_frame_will_be_skipped_observable
+  ["get_current_frame_frameskip_data"] = function()
+    return current_frame_frameskip_data_observable
   end
 }
 return frameskipServiceModule

--- a/scripts/menu.lua
+++ b/scripts/menu.lua
@@ -883,6 +883,7 @@ return {
 												lilith_gps_menu_item,
             lei_lei_stun_menu_item,
             checkbox_menu_item("Tech Throws", training_settings, "p2_throw_tech",0,"The dummy will tech throws at this %."),
+            list_menu_item("Minimum PB Inputs", training_settings, "min_pb_inputs", { "Normal", "4", "5", "6" }, 1, "Set the minimum number of inputs required to get a tech hit (pushblock).\nNormal = 3 inputs, as is normal");
             list_menu_item("Guard", training_settings, "guard", guard,1, "Autoguard will block everything, including unblockable setups.\nBlock will make the dummy tap back for one frame to put them in proxy block.\nCurrently does not work with all moves."),
             -- integer_menu_item("# Guard Frames", training_settings, "p2_refill_timer", 0, 20, false, 0, nil, "This timer controls when the life meter will be refilled.\nOccurs this many seconds after being hit"),
 

--- a/scripts/playerObject.lua
+++ b/scripts/playerObject.lua
@@ -178,7 +178,7 @@ function make_input_set(_value)
 
         if current.p1_tech_hit and not prev.p1_tech_hit then
           local cur_successful_pb_counter = util.tablelength(globals.successful_pb_counter)
-          if cur_sucussful_pb_counter == 1000 then
+          if cur_successful_pb_counter == 1000 then
             table.remove(globals.successful_pb_counter, 1)
             table.insert(globals.successful_pb_counter, 1)
           else

--- a/scripts/training_settings.json
+++ b/scripts/training_settings.json
@@ -88,5 +88,6 @@
   "graph_data_index":1,
   "p1_max_life":288,
   "enable_slot_3":true,
-  "lilith_gps":0
+  "lilith_gps":0,
+  "min_pb_inputs":1
 }


### PR DESCRIPTION
Add the ability to set the minimum number of inputs required to get a tech hit. This functionality otherwise leaves pushblocking intact; i.e.: you are not _guaranteed_ a pushblock once you have met the minimum threshold, but you are guaranteed _not_ to unless you do.

This pull request also features some revision of the frameskip service.

The only issue I have with this work is that future work in this area may require some revision.

Let's say you want to implement guaranteed PBs or something -- you may want a breakpoint and callback at the same spot this one sets all callbacks to `nil`.

It's not a huge deal, but it's something I'm documenting here for future pain enjoyers.