### PR TITLE
Check savestate cfg before playback

### DIFF
--- a/scripts/macro.lua
+++ b/scripts/macro.lua
@@ -993,7 +993,9 @@ macroLuaModule = {
 					playing = false
 					inputstream = nil
 					pausenow = pauseafterplay
-					savestate.load("current_recording")
+					if globals.options.use_recording_savestate == true then
+						savestate.load("current_recording")
+					end
 					playcontrol(true)
 				end
 			end


### PR DESCRIPTION
Bug: When "Looped Playback" is set to true, the value of "Use Savestate Upon Recording" is ignored. The savestate is always loaded, leading to bad behavior.

Added a check to fix this. Tested.