### PR TITLE
Fix dash trainer (tick-based timing POC)

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -243,18 +243,47 @@ local function draw_dash_cancel_trainer()
         local da_len = globals.player_state_service.
             p1_derived_events.dash_attack_lengths
 
-
 		gui.text(base_x, 50 , "Dash\nATK")
         for i, event in ipairs(da_len) do
 			local color = "#FFFFFF"
             local printable = string.format("%dF %dT", event["frame_diff"],
                 event["tick_diff"])
-            -- improvement: expand this for perfect dashes for other chars
-            if p1_char == "Bulleta" and event["frame_diff"] == 4 then
-                color = "#00FF00"
+            -- perfect dashes (fastest consistent dash)
+            -- character-dependent timing from
+            -- https://darkstalkers-web-fc2-com.translate.goog/savior/system-s/dash-s/dash-s.html?_x_tr_sch=http&_x_tr_sl=ja&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp
+            -- tested to be accurate for forward dashes
+            -- if your backdash has different data, it's not supported
+            -- except leilei, where *only* backdash is supported
+            if (p1_char == "Sasquatch")
+                and event["frame_diff"] == 2 then color = "#00FF00"
             end
-			gui.text(base_x, 85 + ((#da_len - i) * 10),
-                printable, color)
+            if (p1_char == "Bulleta"
+                or p1_char == "Anakaris"
+                or p1_char == "Lilith"
+                or p1_char == "Victor"
+                or p1_char == "Lei-Lei")
+                and event["frame_diff"] == 4 then color = "#00FF00"
+            end
+            if (p1_char == "Bishamon"
+                or p1_char == "Q-Bee"
+                or p1_char == "Aulbath")
+                and event["frame_diff"] == 5 then color = "#00FF00"
+            end
+            if (p1_char == "Felicia" or
+                p1_char == "Gallon")
+                and event["frame_diff"] == 6 then color = "#00FF00"
+            end
+            if (p1_char == "Jedah"
+                or p1_char == "Morrigan")
+                and event["frame_diff"] == 9 then color = "#00FF00"
+            end
+            -- Zabel dashing sets the attack flag
+            -- So attack delta is always 0, disable feature for him.
+            if (p1_char ~= "Zabel"
+                and p1_char ~="Demitri") then
+                gui.text(base_x, 85 + ((#da_len - i) * 10),
+                    printable, color)
+            end
         end
 	end
 end

--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -224,12 +224,7 @@ end
 local function draw_dash_cancel_trainer()
 	if globals.options.display_dash_attack_cancel_trainer == true then
 		local p1_char = util.get_character(0xFF8400)
-
-		local copy_of_table = copytable(globals.time_between_dash_start_attack_start)
-		table.sort(copy_of_table, function (left, right) return left < right end)
-
 		local x_location = memory.readdword(0xFF8410)
-
 		local base_x = 0
 		offset_x = 0
 		if globals.options.display_attack_dash_gap_trainer == true then
@@ -241,21 +236,26 @@ local function draw_dash_cancel_trainer()
 		else
 			base_x = 10
 		end
-
 		if globals.options.display_dash_length_trainer == true or globals.options.display_dash_interval_trainer == true then
 			base_x = 10
 		end
 
+        local da_len = globals.player_state_service.
+            p1_derived_events.dash_attack_lengths
 
-		gui.text(base_x, 50 , "Dash\nATK\nCNCL")
-		for i = #globals.time_between_dash_start_attack_start, 1, -1 do
+
+		gui.text(base_x, 50 , "Dash\nATK")
+        for i, event in ipairs(da_len) do
 			local color = "#FFFFFF"
-			if globals.time_between_dash_start_attack_start[i] == copy_of_table[1] then color = "#00FF00" end
-			if globals.time_between_dash_start_attack_start[i] == copy_of_table[#copy_of_table] then
-				color = "#FF0000" 
-			end
-			gui.text(base_x, 85 + ((#globals.time_between_dash_start_attack_start - i) * 10), globals.time_between_dash_start_attack_start[i], color)
-		end
+            local printable = string.format("%dF %dT", event["frame_diff"],
+                event["tick_diff"])
+            -- improvement: expand this for perfect dashes for other chars
+            if p1_char == "Bulleta" and event["frame_diff"] == 4 then
+                color = "#00FF00"
+            end
+			gui.text(base_x, 85 + ((#da_len - i) * 10),
+                printable, color)
+        end
 	end
 end
 -- This function tracks the gap between attack ending and dash starting

--- a/scripts/playerStateService.lua
+++ b/scripts/playerStateService.lua
@@ -68,8 +68,8 @@ local function write_dash_attack_length()
         if #derived_events.dash_attack_lengths > BUFFER_LEN then
             table.remove(derived_events.dash_attack_lengths, 1)
         end
-        print("DEBUG:", record, atk_input_frame, dash_input_frame,
-            atk_input_tick, dash_input_tick)
+        --print("DA DEBUG:", record, atk_input_frame, dash_input_frame,
+        --    atk_input_tick, dash_input_tick)
     end
 end
 table.insert(p1_event_postprocessors, write_dash_attack_length)

--- a/scripts/playerStateService.lua
+++ b/scripts/playerStateService.lua
@@ -1,0 +1,126 @@
+-- module provides bussy logic
+-- listen to queues from rawStateService
+-- populate tables, do processing, whatever
+-- prepare stuff for gui components
+local BUFFER_LEN = 5
+
+-- check if a dash attack started on this tick
+local function dashAttackStarted()
+    local dash_state = globals.truth.p1_state.dash:getValue()
+    local attack_state = globals.truth.p1_state.attack:getValue()
+    if (dash_state.current and attack_state.current and
+            attack_state.previous == false) then
+            return true
+    end
+    return false
+end
+
+-- check if a dash started on this tick
+local function dashStarted()
+    local dash_state = globals.truth.p1_state.dash:getValue()
+    if (dash_state.current and dash_state.previous == false) then
+        return true
+    end
+    return false
+end
+
+local p1_events = {
+    dash = {},
+    dash_attack = {},
+--    jump = {},
+--    jump_attack = {},
+}
+
+-- state checking functions associated to keys of p1_events
+local p1_event_checkers = {
+    dash = dashStarted,
+    dash_attack = dashAttackStarted,
+}
+
+-- information to send to gui
+-- (not atomic game state information)
+local derived_events = {
+    dash_attack_lengths = {},
+}
+
+-- after all the event information is written to p1_events,
+-- run all these.
+local p1_event_postprocessors = {}
+
+
+-- if dash attack occurred, write its length
+local function write_dash_attack_length()
+    if dashAttackStarted() then
+        local dash = p1_events["dash"][#p1_events["dash"]]
+        local atk = p1_events["dash_attack"][#p1_events["dash_attack"]]
+        -- inputs are 2 ticks earlier than the state change
+        -- (with this timing setup)
+        local dash_input_tick = dash.tick - 2
+        local atk_input_tick = atk.tick - 2
+        local dash_input_frame = globals.truth.get_frame_from_tick(
+            dash_input_tick, atk.tick, atk.frame, atk.cycle)
+        local atk_input_frame = globals.truth.get_frame_from_tick(
+            atk_input_tick, atk.tick, atk.frame, atk.cycle)
+        local record = {}
+        record["frame_diff"] = atk_input_frame - dash_input_frame
+        record["tick_diff"] = atk_input_tick - dash_input_tick
+        table.insert(derived_events.dash_attack_lengths, record)
+        if #derived_events.dash_attack_lengths > BUFFER_LEN then
+            table.remove(derived_events.dash_attack_lengths, 1)
+        end
+        print("DEBUG:", record, atk_input_frame, dash_input_frame,
+            atk_input_tick, dash_input_tick)
+    end
+end
+table.insert(p1_event_postprocessors, write_dash_attack_length)
+
+
+-- get_event_scribe returns a func to be passed to queue:subscribe
+-- pass a bool function of state, table, and max table size
+-- the bool function will be tested every tick
+-- if true, the timing info (tick/frame/cycle) is appended to the table
+--
+-- state_test: function that returns a bool based on state
+--   ex: dashStarted, dashAttackStarted
+-- ledger: a table to update
+-- max_ledger_size: max table length before earliest entry is deleted
+local function get_event_scribe(state_test, ledger, max_ledger_size)
+    local function subscribe_func(tick)
+        if state_test() then
+            local timings = {}
+            timings["tick"] = tick
+            timings["frame"] = globals.truth.framer:getValue()
+            timings["cycle"] = globals.truth.cycler:getValue()
+            table.insert(ledger, timings)
+            if #ledger > max_ledger_size then
+                table.remove(ledger, 1)
+            end
+        end
+    end
+    return subscribe_func
+end
+
+local playerStateServiceModule = {
+    -- initialize after globals.truth and globals.dummy_state_service
+    ["registerStart"] = function()
+        -- scribes will handle recording state data in a global table
+        local scribes = {}
+        for event,ledger in pairs(p1_events) do
+            table.insert(scribes, get_event_scribe(
+                p1_event_checkers[event], ledger, BUFFER_LEN))
+        end
+
+        globals.truth.ticker:subscribe(function(tick)
+            -- record all event data
+            for _, scribe in ipairs(scribes) do
+                scribe(tick)
+            end
+            for _, postprocessor in ipairs(p1_event_postprocessors) do
+                postprocessor()
+            end
+        end)
+    end,
+    ["p1_events"] = p1_events,
+    ["p1_derived_events"] = derived_events,
+}
+return playerStateServiceModule

--- a/scripts/rawStateService.lua
+++ b/scripts/rawStateService.lua
@@ -1,0 +1,203 @@
+-- Provides:
+-- * input logging in console
+-- * handles updates for globals.dummy_state_service
+-- * exposes p1_state, a table of state delta observables
+--     * p1_state["dash"] is an observable you can follow
+--     * or use p1_state["dash"]:getValue() for immediate result
+--       * returned object has keys "current", "previous",
+--         "cycle", "frame", "tick"
+--     * this can be refactored but it works
+local exposed_deltas = {}
+
+-- ticker:getValue() is like emu.framecount() for logical frames (ticks)
+local ticker = Rx.BehaviorSubject.create(0)
+-- framer updates at same time as ticker
+-- but on skipped ticks, framer will send a duplicate frame value
+-- ex: 1,2,3,3,4 ...
+local framer = Rx.BehaviorSubject.create(0)
+-- cycler updates at the same time as ticker
+-- it gives turbo cycle: 0,1,2 are drawn ticks, 3 is skipped tick
+local cycler = Rx.BehaviorSubject.create(nil)
+
+
+
+-- Given a buffered stream of tables (ReplaySubject),
+-- and a key for those tables, return a stream of delta events for given key
+-- Returns a BehaviorSubject, last event can be read with :getValue()
+-- Inherits the k:v pairs for "cycle", "frame", "tick", if they exist.
+-- @arg {Rx.ReplaySubject} table_producer - a buffered channel of tables
+-- @arg {string} key - a key for the ReplaySubject table stream
+-- @returns {Rx.BehaviorSubject} - has delta info for given key
+-- @returns {Rx.Subscription} - cancelfunc
+local function pluckDeltaSubject(table_producer, key)
+	if tostring(table_producer) ~= 'ReplaySubject' then
+		error('Expected Rx.ReplaySubject')
+	end
+	if not key or type(key) ~= 'string' then
+		error('Expected string key')
+	end
+
+	local function get_delta()
+		local buffer_size = #table_producer.buffer
+        local initial = {}
+		if buffer_size < 1 then
+			return initial
+		end
+		local current = table_producer.buffer[buffer_size][1]
+        initial["cycle"]   = current["cycle"]
+        initial["frame"]   = current["frame"]
+        initial["tick"]    = current["tick"]
+        initial["current"] = current[key]
+		if buffer_size < 2 then
+			return initial
+		end
+        local previous = table_producer.buffer[buffer_size - 1][1]
+		initial["previous"] = previous[key]
+		return initial
+	end
+
+	local initial_value = get_delta()
+	local delta_subject = Rx.BehaviorSubject.create(initial_value)
+
+	-- don't see a way to make the behaviorsubject subscribe to something
+	-- directly; so make an observer that sends on behaviorsubject
+	-- (following rx.Observable:takeLast, which hates ReplaySubjects)
+	-- this subscription ignores sent values and just uses enclosed buffer
+	local subscription = table_producer:subscribe(function()
+		delta_subject(get_delta())
+	end)
+
+	return delta_subject, subscription
+end
+
+
+-- given a tick, what frame did it occur on?
+-- target_tick: the tick you wanna know the frame of
+-- known_tick, known_frame, known_cycle: tick/frame/cycle from same tick
+--   these can be obtained from ticker, framer, cycler
+-- output the frame associated to target_tick
+local function get_frame_from_tick(target_tick, known_tick, known_frame,
+    known_cycle)
+    local tick_delta = known_tick - target_tick
+    -- WLOG known_tick >= target_tick.
+    if tick_delta < 0 then
+        local base_tick = known_tick + 4 * (math.ceil(tick_delta / 4))
+        local base_frame = known_frame + 3 * (math.ceil(tick_delta / 4))
+        return get_frame_from_tick(target_tick,
+            base_tick, base_frame, known_cycle)
+    end
+    -- first get frame of greatest tick <= target tick
+    -- (with cycle same as starting cycle)
+    -- want smallest multiple of 4 greater than tick delta
+    local base_tick = known_tick - 4 * (math.ceil(tick_delta / 4))
+    local base_cycle = known_cycle
+    local base_frame = known_frame - 3 * (math.ceil(tick_delta / 4))
+    while base_tick < target_tick do
+        base_tick = base_tick + 1
+        base_cycle = math.fmod(base_cycle + 1,4)
+        -- don't increment frame when going from cycle 1 to 2
+        base_frame = base_frame + ((base_cycle ~= 2) and 1 or 0)
+    end
+    return base_frame
+end
+
+local function print_deltas()
+    for k,v in pairs(exposed_deltas) do
+	    local state = v:getValue()
+        local cycle, frame, tick = state.cycle, state.frame, state.tick
+	    if state.previous ~= state.current then
+		local state_description = "end"
+		if state.current then
+			state_description = "begin"
+		end
+
+        local timestamp = string.format("cycle %d; frame %d (tick %d):",
+            cycle, frame, tick)
+		print(timestamp, k, state_description, emu.framecount())
+	    end
+    end
+end
+
+-- input logging util:
+-- accept list of 6 bools representing presses
+-- [LP, MP, HP, LK, MK, HK], provided by inputHistory.lua
+-- return string of pressed buttons
+local button_names = {"LP ", "MP ", "HP ", "LK ", "MK ", "HK "}
+local function format_btns(buttons)
+  local pressed_names = ""
+  for i = 1,6 do
+    local nextString = "   "
+    if buttons[i]==true then
+      nextString = button_names[i]
+    end
+    pressed_names = pressed_names .. nextString
+  end
+  return pressed_names
+end
+
+local rawStateServiceModule = {
+  ["registerStart"] = function()
+	  -- log inputs to console
+    local p1_input_history_subscription = globals.history_service_p1:subscribe(function(input_data)
+	local cycle, frame, tick = cycler:getValue(), framer:getValue(), ticker:getValue()
+	local dir = input_data.direction
+	local btns = format_btns(input_data.buttons)
+	print(string.format("cycle %d; frame %d (tick %d): %d %s",
+		cycle, frame, tick, dir, btns), emu.framecount())
+      end)
+
+--    local history_sub_p2 = globals.history_service_p2:subscribe(print)
+
+    exposed_deltas["dash"] = pluckDeltaSubject(
+    	globals.dummy_state_service, 'p1_is_dashing')
+    exposed_deltas["attack"] = pluckDeltaSubject(
+    	globals.dummy_state_service, 'p1_is_attacking')
+    exposed_deltas["crouch"] = pluckDeltaSubject(
+    	globals.dummy_state_service, 'p1_is_crouching')
+    exposed_deltas["air"] = pluckDeltaSubject(
+    	globals.dummy_state_service, 'p1_in_air')
+
+    -- ticker updates whenever we read the tick mid-frame
+    -- dummy_state_service also updates at this time
+    globals.frameskipService.get_current_frame_frameskip_data():
+    	subscribe(function(foo)
+            print_deltas() -- view info about last frame
+            -- before we overwrite last frame's timers
+
+            local tick = ticker:getValue()+1
+            local cycle = math.fmod(foo.calculated_frameskip_index, 4)
+            local frame = framer:getValue()
+            if cycle ~= 2 then
+                frame = frame+1
+            end
+            -- ^ The cycle numbers correspond to the frameskip flags
+            --   exposed by the frameskip service in the following way.
+            -- print(cycle, foo.next_frame_will_be_skipped,
+            --       foo.last_frame_was_skipped)
+            -- 0 false false
+            -- 1 true false
+            -- 2 false true
+            -- 3 false false
+
+            globals.dummy_state_service_updater(cycle, frame, tick)
+
+            -- Clocks must update last
+            -- Clock consumers will assume that state data is fresh
+            cycler(cycle)
+            framer(frame)
+            ticker(tick)
+        end)
+  end,
+  ["p1_state"] = exposed_deltas,
+  -- counts logical frames (ticks)
+  ["ticker"] = ticker,
+  -- counts animation frames, updates on same ticks as emu.framecount
+  -- will repeat last value on the skipped tick
+  ["framer"] = framer,
+  -- counts mod 4 turbo cycle (intended for use on turbo 3)
+  ["cycler"] = cycler,
+  -- compute past frame a tick landed on, given a reference triple:
+  -- tick+frame+cycle from the same tick
+  ["get_frame_from_tick"] = get_frame_from_tick,
+}
+return rawStateServiceModule

--- a/scripts/rawStateService.lua
+++ b/scripts/rawStateService.lua
@@ -113,7 +113,7 @@ local function print_deltas()
 
         local timestamp = string.format("cycle %d; frame %d (tick %d):",
             cycle, frame, tick)
-		print(timestamp, k, state_description, emu.framecount())
+		print(timestamp, k, state_description)
 	    end
     end
 end
@@ -143,7 +143,7 @@ local rawStateServiceModule = {
 	local dir = input_data.direction
 	local btns = format_btns(input_data.buttons)
 	print(string.format("cycle %d; frame %d (tick %d): %d %s",
-		cycle, frame, tick, dir, btns), emu.framecount())
+		cycle, frame, tick, dir, btns))
       end)
 
 --    local history_sub_p2 = globals.history_service_p2:subscribe(print)


### PR DESCRIPTION
The existing timing scheme has three main flaws:
1. It doesn't collect data at guaranteed times. I was able to verify that the current method is sometimes a frame late or early to read. This is separate from skipped frames: it's early or late on animation frames.
2. It only collects data on drawn ticks, so we're missing data from the skipped ticks.
3. It measures "how many frames elapsed between these state changes?" when it really should measure "how many frames elapsed between the inputs that caused these state changes?"

This third point is subtle. When we detect an input, some number of ticks (not frames) must elapse before there is a visible state change in memory. For dashing and attacking, the state change is visible 2 ticks after the input. This means that the tick delta between "press dash" and "press attack" is the same as the tick delta between "observe dash state" and "observe attack state". But if you replace "tick delta" with "frame delta" in the last sentence, it's no longer true. When you shift two events by a constant number of ticks, this does not necessarily preserve the frame difference between those two events.

New system fixes all these points:
* Collect all data by hooking into RegisterExec from MBD's frameskip service: this is the piece of code that checks frameskip timers. I believe that this executes before any of the relevant gamestate changes in the frame. If any issues are found with this, we can hook into an earlier RegisterExec before these things are checked, but I think it's fine the way it is.
* Store frame, tick, cycle information for every event we wish to log
* Using this information, observe state changes on precise ticks, calculate the corresponding input ticks (two ticks earlier than state change), calculate the frames on which those ticks occur, and then we get the frame delta between inputs.

Some of this design is sketchy but I've tried to lay out a system that will allow us to easily hook in more raw data and process it into tables.

Also added an input display in the log file, showing cycle/frame/tick information for each press.