### PR TITLE
feature: add input display for tech hit inputs

### DIFF
--- a/scripts/hud.lua
+++ b/scripts/hud.lua
@@ -1,3 +1,5 @@
+local tech_hit_inputs = require './tech-hit-inputs'
+
 local function draw_fd()
 	mid_width = 23
 	mid_height = 47
@@ -187,6 +189,7 @@ local function draw_pb_stats()
 			gui.text( 210, 63, "%" .. string.format("%02d", util.tablelength(globals.successful_pb_counter) / util.tablelength(globals.total_pb_attempt_counter) * 100), "#00FF00")
 		end
 		gui.text( 172, 73, "Fail: " .. util.tablelength(globals.total_pb_attempt_counter) - util.tablelength(globals.successful_pb_counter), "#FF0000")
+		tech_hit_inputs()
 	end
 end
 

--- a/scripts/tech-hit-inputs.lua
+++ b/scripts/tech-hit-inputs.lua
@@ -1,0 +1,69 @@
+---@author VMP_MBD (MBDesu)
+
+-- consts
+local P1_INPUT_ADDR = 0xff8522
+local P1_TECH_HIT_INPUT_COUNT_ADDR = 0xff8570
+local TECH_HIT_SUCCESS_CHECK_ADDR = 0x2762a
+local INPUT_REPRESENTATIONS = { 'LP', 'MP', 'HP', '', 'LK', 'MK', 'HK' }
+
+-- local state
+local last_num_inputs = 0
+local tech_hit_input_history = {}
+
+local btst = function(bit_pos, value)
+  return bit.band(bit.lshift(1, bit_pos), value) > 0
+end
+
+---Converts a raw button input value from memory into
+---a text representation of all pressed buttons
+---@param raw_input number
+---@return string
+local parse_input = function(raw_input)
+  local pressed_buttons = {}
+
+  for i, representation in pairs(INPUT_REPRESENTATIONS) do
+    if btst(i - 1, raw_input) then
+      pressed_buttons[#pressed_buttons + 1] = representation
+    end
+  end
+  return table.concat(pressed_buttons, '+')
+end
+
+local function get_count()
+  return memory.readbyte(P1_TECH_HIT_INPUT_COUNT_ADDR)
+end
+
+local function update_tech_hit_input_history(did_tech_hit)
+  local current_num_inputs = get_count()
+  if last_num_inputs > current_num_inputs then
+    tech_hit_input_history = {}
+  end
+  if last_num_inputs ~= current_num_inputs then
+    last_num_inputs = current_num_inputs
+    local history_entry =
+          {current_num_inputs, parse_input(memory.readbyte(P1_INPUT_ADDR))}
+    if did_tech_hit == true then
+      history_entry[3] = 'TECH HIT'
+    end
+    tech_hit_input_history[#tech_hit_input_history + 1] = history_entry
+  end
+end
+
+memory.registerexec(TECH_HIT_SUCCESS_CHECK_ADDR, function()
+  -- Z flag will contain indication of success; second bit of SR register
+  -- additionally, we only reach 0x2762a on successful tech hit input
+  local did_tech_hit = not btst(2, memory.getregister('m68000.sr'))
+  update_tech_hit_input_history(did_tech_hit)
+end)
+
+local guiRegister = function()
+  for i, entry in pairs(tech_hit_input_history) do
+    if #entry < 3 then
+      gui.text(5, emu.screenheight() - 160 + 10 * i, entry[1] .. ': ' .. entry[2])
+    else
+      gui.text(5, emu.screenheight() - 160 + 10 * i, entry[1] .. ': ' .. entry[2] .. '     ' .. entry[3])
+    end
+  end
+end
+
+return guiRegister

--- a/scripts/tech-hit-inputs.lua
+++ b/scripts/tech-hit-inputs.lua
@@ -1,39 +1,75 @@
 ---@author VMP_MBD (MBDesu)
 
+require 'gd'
+
 -- consts
 local P1_INPUT_ADDR = 0xff8522
 local P1_TECH_HIT_INPUT_COUNT_ADDR = 0xff8570
 local TECH_HIT_SUCCESS_CHECK_ADDR = 0x2762a
 local INPUT_REPRESENTATIONS = { 'LP', 'MP', 'HP', '', 'LK', 'MK', 'HK' }
+local ICON_FILE = 'scrolling-input/capcom-8.png'
+local BLANK_PNG_BYTES = {
+  '0x89', '0x50', '0x4E', '0x47', '0x0D', '0x0A', '0x1A', '0x0A', '0x00',
+  '0x00', '0x00', '0x0D', '0x49', '0x48', '0x44', '0x52', '0x00', '0x00',
+  '0x00', '0x40', '0x00', '0x00', '0x00', '0x20', '0x01', '0x03', '0x00',
+  '0x00', '0x00', '0x98', '0x53', '0xEC', '0xC7', '0x00', '0x00', '0x00',
+  '0x03', '0x50', '0x4C', '0x54', '0x45', '0x00', '0x00', '0x00', '0xA7',
+  '0x7A', '0x3D', '0xDA', '0x00', '0x00', '0x00', '0x01', '0x74', '0x52',
+  '0x4E', '0x53', '0x00', '0x40', '0xE6', '0xD8', '0x66', '0x00', '0x00',
+  '0x00', '0x0D', '0x49', '0x44', '0x41', '0x54', '0x18', '0x95', '0x63',
+  '0x60', '0x18', '0x05', '0xF8', '0x00', '0x00', '0x01', '0x20', '0x00',
+  '0x01', '0xBF', '0xC1', '0xB1', '0xA8', '0x00', '0x00', '0x00', '0x00',
+  '0x49', '0x45', '0x4E', '0x44', '0xAE', '0x42', '0x60', '0x82'
+}
 
 -- local state
 local last_num_inputs = 0
 local tech_hit_input_history = {}
+local icons = {}
+
+local png_str_from_bytes = function(bytes)
+  local str = ''
+  for _, b in pairs(bytes) do
+    str = str .. string.char(b)
+  end
+  return str
+end
+
+local image_setup = function()
+  local icon_sheet = gd.createFromPng(ICON_FILE)
+  for i = 1,6 do
+    local tmp = gd.createFromPngStr(png_str_from_bytes(BLANK_PNG_BYTES))
+    gd.copyResampled(tmp, icon_sheet, 0, 0, 0, 8 * (8 + (i - 1)), 8, 8, 8, 8)
+    icons[#icons + 1] = tmp:gdStr()
+  end
+end
 
 local btst = function(bit_pos, value)
   return bit.band(bit.lshift(1, bit_pos), value) > 0
 end
 
 ---Converts a raw button input value from memory into
----a text representation of all pressed buttons
+---an icons representation of all pressed buttons
 ---@param raw_input number
----@return string
+---@return table<string>
 local parse_input = function(raw_input)
   local pressed_buttons = {}
 
-  for i, representation in pairs(INPUT_REPRESENTATIONS) do
-    if btst(i - 1, raw_input) then
-      pressed_buttons[#pressed_buttons + 1] = representation
+  for i = 1,7 do
+    if i ~= 4 and btst(i - 1, raw_input) then
+      local icon
+      if i < 4 then icon = icons[i] else icon = icons[i - 1] end
+      pressed_buttons[#pressed_buttons + 1] = icon
     end
   end
-  return table.concat(pressed_buttons, '+')
+  return pressed_buttons
 end
 
-local function get_count()
+local get_count = function()
   return memory.readbyte(P1_TECH_HIT_INPUT_COUNT_ADDR)
 end
 
-local function update_tech_hit_input_history(did_tech_hit)
+local update_tech_hit_input_history = function(did_tech_hit)
   local current_num_inputs = get_count()
   if last_num_inputs > current_num_inputs then
     tech_hit_input_history = {}
@@ -56,13 +92,20 @@ memory.registerexec(TECH_HIT_SUCCESS_CHECK_ADDR, function()
   update_tech_hit_input_history(did_tech_hit)
 end)
 
+image_setup()
+
 local guiRegister = function()
   for i, entry in pairs(tech_hit_input_history) do
-    if #entry < 3 then
-      gui.text(5, emu.screenheight() - 160 + 10 * i, entry[1] .. ': ' .. entry[2])
-    else
-      gui.text(5, emu.screenheight() - 160 + 10 * i, entry[1] .. ': ' .. entry[2] .. '     ' .. entry[3])
-    end
+      print(entry)
+      local y = emu.screenheight() - 160 + 10 * i
+      gui.text(5, y, entry[1] .. ': ')
+      for j, icon in pairs(entry[2]) do
+        local x = 5 + 10 * j
+        gui.gdoverlay(x, y - 1, icon)
+      end
+      if entry[3] ~= nil then
+        gui.text((#entry[2] + 1) * 10 + 7, y, 'TECH HIT')
+      end
   end
 end
 


### PR DESCRIPTION
This feature adds an input display for tech hits, as shown below, per @pythmere's request.

![tech hit input display](https://media.discordapp.net/attachments/702296783799320646/1286576280950804520/image.png?ex=66ee6908&is=66ed1788&hm=6b1c8c6b4d64949d83d5bd4aba3dfc644516e688fd159351b011e31c5e92f389&=&format=webp&quality=lossless&width=1642&height=1336)
(also pictured: fun bug with the PB stats display where if you tech hit the same string twice while in blockstun, you can achieve 200%+ and GO BEYOND)

It works by hooking the instruction at `0x27612` and reading the input buffer. This instruction is a check to see if a tech hit was successful and is after the tech hit input counter has been updated in the game internally.

This feature is toggleable through the existing `display_pb_stats` global config variable.

This PR does commit a sin of adding `tech-hit-inputs.lua` as a dependency of `hud.lua`, but I think that's ok.